### PR TITLE
Add yamlfmt, Ansible Lint and Terraform Lint to Jenkins slave nodes

### DIFF
--- a/ansible/jenkins_master_and_nodes/playbooks/jenkins_nodes.yml
+++ b/ansible/jenkins_master_and_nodes/playbooks/jenkins_nodes.yml
@@ -51,11 +51,35 @@
             repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/hashicorp.asc] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
             update_cache: true
 
-        - name: Installing Docker, Terraform and Ansible
+        - name: Installing Docker, Terraform, Ansible
           ansible.builtin.apt:
             name:
               - docker-ce
               - docker-ce-cli
               - terraform
               - ansible
+              - unzip
+            state: present
+
+        - name: Installing yamlfmt
+          ansible.builtin.unarchive:
+            src: https://github.com/google/yamlfmt/releases/download/v0.14.0/yamlfmt_0.14.0_Linux_x86_64.tar.gz
+            dest: /usr/local/bin
+            remote_src: true
+            owner: jenkins
+            group: jenkins
+            mode: '0700'
+
+        - name: Installing Terraform Lint
+          ansible.builtin.unarchive:
+            src: https://github.com/terraform-linters/tflint/releases/download/v0.54.0/tflint_linux_amd64.zip
+            dest: /usr/local/bin
+            remote_src: true
+            owner: jenkins
+            group: jenkins
+            mode: '0700'
+
+        - name: Installing Ansible Lint
+          ansible.builtin.apt:
+            name: ansible-lint
             state: present


### PR DESCRIPTION
Add yamlfmt, Ansible Lint and Terraform Lint to Jenkins slave nodes to be used in future pipelines.