### PR TITLE
Add static IP variable for Jenkins nodes and open ports 80/tcp and 443 for NGINX deployment

### DIFF
--- a/terraform/jenkins_master_and_nodes/main.tf
+++ b/terraform/jenkins_master_and_nodes/main.tf
@@ -28,6 +28,7 @@ module "jenkins_master" {
   jenkins_instance_name = "vpanainte-jenkins-master"
   jenkins_instance_id   = "jenkins-master"
   jenkins_internal_ip   = "10.0.0.2"
+  jenkins_public_ip     = var.jenkins_master_static_public_ip
 }
 
 module "jenkins_node" {
@@ -39,4 +40,5 @@ module "jenkins_node" {
   jenkins_instance_id   = "jenkins-node"
   jenkins_instance_type = "e2-highcpu-4"
   jenkins_internal_ip   = "10.0.0.${count.index + 3}"
+  jenkins_public_ip     = null
 }

--- a/terraform/jenkins_master_and_nodes/modules/instance/main.tf
+++ b/terraform/jenkins_master_and_nodes/modules/instance/main.tf
@@ -5,7 +5,9 @@ resource "google_compute_instance" "jenkins" {
 
   network_interface {
     subnetwork = var.subnet_id
-    access_config {}
+    access_config {
+      nat_ip = var.jenkins_public_ip
+    }
     network_ip = var.jenkins_internal_ip
   }
 

--- a/terraform/jenkins_master_and_nodes/modules/instance/variables.tf
+++ b/terraform/jenkins_master_and_nodes/modules/instance/variables.tf
@@ -20,6 +20,11 @@ variable "jenkins_internal_ip" {
   default     = null
 }
 
+variable "jenkins_public_ip" {
+  type        = string
+  description = "Jenkins instance public ip"
+}
+
 variable "jenkins_image" {
   type        = string
   description = "Boot disk image"
@@ -29,4 +34,5 @@ variable "jenkins_image" {
 variable "jenkins_instance_id" {
   type        = string
   description = "Instance ID"
+
 }

--- a/terraform/jenkins_master_and_nodes/modules/vpc/main.tf
+++ b/terraform/jenkins_master_and_nodes/modules/vpc/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_firewall" "jenkins" {
 
   allow {
     protocol = "tcp"
-    ports    = ["8080"]
+    ports    = ["8080", "80", "443"]
   }
 
   source_ranges      = ["0.0.0.0/0"]

--- a/terraform/jenkins_master_and_nodes/modules/vpc/main.tf
+++ b/terraform/jenkins_master_and_nodes/modules/vpc/main.tf
@@ -49,12 +49,26 @@ resource "google_compute_firewall" "firewall_v6" {
   network = google_compute_network.vpc.name
 }
 
-resource "google_compute_firewall" "jenkins" {
-  name = "vpanainte-jenkins"
+resource "google_compute_firewall" "jenkins-http-https" {
+  name = "vpanainte-jenkins-http-https"
 
   allow {
     protocol = "tcp"
-    ports    = ["8080", "80", "443"]
+    ports    = ["80", "443"]
+  }
+
+  source_ranges      = ["0.0.0.0/0"]
+  destination_ranges = ["10.0.0.2/32"]
+
+  network = google_compute_network.vpc.name
+}
+
+resource "google_compute_firewall" "jenkins-quic" {
+  name = "vpanainte-jenkins-quic"
+
+  allow {
+    protocol = "udp"
+    ports    = ["443"]
   }
 
   source_ranges      = ["0.0.0.0/0"]

--- a/terraform/jenkins_master_and_nodes/variables.tf
+++ b/terraform/jenkins_master_and_nodes/variables.tf
@@ -17,3 +17,7 @@ variable "jenkins_nodes_number" {
   type        = number
   description = "Jenkins nodes amount"
 }
+variable "jenkins_master_static_public_ip" {
+  type        = string
+  description = "Jenkins master static public IP address"
+}


### PR DESCRIPTION
Add static IP variable for Jenkins nodes and open ports 80/tcp and 443 for NGINX deployment